### PR TITLE
Changement de "Intel" par "x86" dans l'architecture supportée

### DIFF
--- a/app/templates/home.html.twig
+++ b/app/templates/home.html.twig
@@ -16,7 +16,7 @@
     <li><a href="{{ links.win64 }}">Téléchargement 64 Bits | exe</a></li>
 </ul>
 
-<h2 id="linux">Linux (Intel)</h2>
+<h2 id="linux">Linux (x86)</h2>
 <ul>
     <li><a href="{{ links.lin32 }}">Téléchargement 32 Bits | tar.bz2</a></li>
     <li><a href="{{ links.lin64 }}">Téléchargement 64 Bits | tar.bz2</a></li>


### PR DESCRIPTION
Changement de "Intel" par "x86" dans l'architecture supportée par le téléchargement pour Linux
