### PR TITLE
bz2 -> xz

### DIFF
--- a/app/classes/Nightly/Version.php
+++ b/app/classes/Nightly/Version.php
@@ -51,8 +51,8 @@ class Version
         return [
             'win32' => $lead_link . 'win32.installer.exe',
             'win64' => $lead_link . 'win64.installer.exe',
-            'lin32' => $lead_link . 'linux-i686.tar.bz2',
-            'lin64' => $lead_link . 'linux-x86_64.tar.bz2',
+            'lin32' => $lead_link . 'linux-i686.tar.xz',
+            'lin64' => $lead_link . 'linux-x86_64.tar.xz',
             'macos' => $lead_link . 'mac.dmg',
         ];
     }

--- a/app/templates/home.html.twig
+++ b/app/templates/home.html.twig
@@ -37,8 +37,8 @@
 <div class="downloads" id="linux">
   <h2>Nightly pour Linux (x86)</h2>
   <ul>
-      <li><a class="button" data-link="lin32" href="{{ links.lin32 }}">Télécharger (32 bits | tar.bz2)</a></li>
-      <li><a class="button" data-link="lin64" href="{{ links.lin64 }}">Télécharger (64 bits | tar.bz2)</a></li>
+      <li><a class="button" data-link="lin32" href="{{ links.lin32 }}">Télécharger (32 bits | tar.xz)</a></li>
+      <li><a class="button" data-link="lin64" href="{{ links.lin64 }}">Télécharger (64 bits | tar.xz)</a></li>
   </ul>
   <!--
   <div class="bottom-links">


### PR DESCRIPTION
Les packages Linux sont maintenant des xz, donc les liens actuels Linux sont des liens morts.
Ceci devrait corriger. (non testé)